### PR TITLE
Update mongodb driver to 3.6.0 as prerequisite for mLab to Atlas migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "marked": "^0.3.5",
     "method-override": "^2.3.5",
     "moment": "^2.10.6",
-    "mongodb": "^2.0.42",
+    "mongodb": "^3.6.0",
     "nice-json2csv": "^0.2.0",
     "normalize.css": "^3.0.3",
     "numeral": "^1.5.3",


### PR DESCRIPTION
See https://docs.mlab.com/how-to-migrate-sandbox-heroku-addons-to-atlas/ guide (prerequisites section) and the compatibility grid for the node driver here: https://docs.mongodb.com/drivers/node/compatibility