### PR TITLE
Mapbox updates

### DIFF
--- a/app/components/route_handlers/projects/show/tilemap/subcomponents/map/subcomponents/mapper/root_view.js
+++ b/app/components/route_handlers/projects/show/tilemap/subcomponents/map/subcomponents/mapper/root_view.js
@@ -92,7 +92,8 @@ class RootView {
 	 */
 	render() {
 		L.mapbox.accessToken = 'pk.eyJ1Ijoicm9zc3ZhbmRlcmxpbmRlIiwiYSI6ImRxc0hRR28ifQ.XwCYSPHrGbRvofTV-CIUqw'
-		this.map = L.mapbox.map(this.elId, 'rossvanderlinde.874ab107', this.getMapOptions())
+		this.map = L.mapbox.map(this.elId, '', this.getMapOptions())
+			.addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/light-v10'))
 		this.props.setMap(this.map)
 		this.setupMap()
 		this.hideAttribution()

--- a/app/models/shape_file.js
+++ b/app/models/shape_file.js
@@ -1,7 +1,7 @@
 // Model used to handle geo shape files, from download and geojson conversion to fetching once the app is running.
 import _ from 'underscore'
 import $ from 'jquery'
-import topojson from 'topojson'
+import * as topojson from 'topojson'
 
 import * as base from './base.js'
 import seed from './../../db/seeds/shape_files.json'

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jquery": "^2.1.4",
     "kerberos": "0.0.17",
     "leaflet": "^0.7.7",
-    "mapbox.js": "^2.2.3",
+    "mapbox.js": "3.2.1",
     "marked": "^0.3.5",
     "method-override": "^2.3.5",
     "moment": "^2.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,9 +1307,10 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-corslite@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/corslite/-/corslite-0.0.6.tgz#622954e14c33852123c4c68fa3deffa9e2d1c896"
+corslite@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/corslite/-/corslite-0.0.7.tgz#8e451db5320a7556de1ef78d9bd3566343077721"
+  integrity sha1-jkUdtTIKdVbeHveNm9NWY0MHdyE=
 
 crc@3.4.1:
   version "3.4.1"
@@ -3079,7 +3080,12 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leaflet@0.7.7, leaflet@^0.7.7:
+leaflet@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.4.0.tgz#d5f56eeb2aa32787c24011e8be4c77e362ae171b"
+  integrity sha512-x9j9tGY1+PDLN9pcWTx9/y6C5nezoTMB8BLK5jTakx+H7bPlnbCHfi9Hjg+Qt36sgDz/cb9lrSpNQXmk45Tvhw==
+
+leaflet@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-0.7.7.tgz#1e352ba54e63d076451fa363c900890cb2cf75ee"
 
@@ -3552,15 +3558,15 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-mapbox.js@^2.2.3:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/mapbox.js/-/mapbox.js-2.4.0.tgz#c43b084a5dd71334c83ee1df28fa67443d73c29c"
+mapbox.js@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/mapbox.js/-/mapbox.js-3.2.1.tgz#4bacfa026a4adbd103c74ed910e3435720fc0333"
+  integrity sha512-7HPYeqtpD8d+1NqwZhcwys4Hvacyxd/skLD+snIJ0Cfdf9A5HQx+qwnyf02scQ0O4hh49R4kilsoZMyywBiCFg==
   dependencies:
-    corslite "0.0.6"
-    isarray "0.0.1"
-    leaflet "0.7.7"
-    mustache "2.2.1"
-    sanitize-caja "0.1.3"
+    corslite "0.0.7"
+    leaflet "1.4.0"
+    mustache "3.0.1"
+    sanitize-caja "0.1.4"
 
 marked@^0.3.5:
   version "0.3.6"
@@ -3793,9 +3799,10 @@ multipipe@^0.1.0, multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
-mustache@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.2.1.tgz#2c40ca21c278f53150682bcf9090e41a3339b876"
+mustache@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-3.0.1.tgz#873855f23aa8a95b150fb96d9836edbc5a1d248a"
+  integrity sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==
 
 nan@2.4.x, nan@^2.3.0, nan@^2.3.2:
   version "2.4.0"
@@ -5025,9 +5032,10 @@ safe-buffer@~5.1.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-sanitize-caja@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/sanitize-caja/-/sanitize-caja-0.1.3.tgz#cefbd7cb0e907bea74e8abcb8e86753ec5445576"
+sanitize-caja@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/sanitize-caja/-/sanitize-caja-0.1.4.tgz#7803e8e452b8e3bacb342dbd93adb885acd078af"
+  integrity sha1-eAPo5FK447rLNC29k624hazQeK8=
 
 sass-graph@^2.1.1:
   version "2.1.2"
@@ -5534,6 +5542,16 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
+uglify-js@^2.4.19:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
 uglify-js@~2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.2.5.tgz#a6e02a70d839792b9780488b7b8b184c095c99c7"
@@ -5887,11 +5905,6 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yarn@^1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yazl@^2.1.0:
   version "2.4.2"


### PR DESCRIPTION
This pull request:

1. Updates our use of mapbox.js in accordance with the [Modern Static Tiles API ](https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/) -- See commit for more details.
2. Updates mapbox.js to the latest possible version
3. Changes an import to be compatible with ES6 (it was causing an error for me locally, not sure exactly why)